### PR TITLE
Feat: Support additional cachers 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,17 +7,19 @@ NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
 
 try:
-    from .cache_node import CacheModel
+    from .cache_nodes import CacheModelAdaptive, CacheModelPeriodic
     from .compile_node import CompileModel
 
     PRUNA_NODE_CLASS_MAPPINGS = {
         "CompileModel": CompileModel,
-        "CacheModel": CacheModel,
+        "CacheModelAdaptive": CacheModelAdaptive,
+        "CacheModelPeriodic": CacheModelPeriodic,
     }
 
     PRUNA_NODE_DISPLAY_NAME_MAPPINGS = {
         "CompileModel": "Pruna Compile",
-        "CacheModel": "Pruna Cache",
+        "CacheModelAdaptive": "Pruna Cache Adaptive",
+        "CacheModelPeriodic": "Pruna Cache Periodic",
     }
     NODE_CLASS_MAPPINGS.update(PRUNA_NODE_CLASS_MAPPINGS)
     NODE_DISPLAY_NAME_MAPPINGS.update(PRUNA_NODE_DISPLAY_NAME_MAPPINGS)

--- a/__init__.py
+++ b/__init__.py
@@ -7,19 +7,21 @@ NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
 
 try:
-    from .cache_nodes import CacheModelAdaptive, CacheModelPeriodic
+    from .cache_nodes import CacheModelAdaptive, CacheModelAuto, CacheModelPeriodic
     from .compile_node import CompileModel
 
     PRUNA_NODE_CLASS_MAPPINGS = {
         "CompileModel": CompileModel,
         "CacheModelAdaptive": CacheModelAdaptive,
         "CacheModelPeriodic": CacheModelPeriodic,
+        "CacheModelAuto": CacheModelAuto,
     }
 
     PRUNA_NODE_DISPLAY_NAME_MAPPINGS = {
         "CompileModel": "Pruna Compile",
         "CacheModelAdaptive": "Pruna Cache Adaptive",
         "CacheModelPeriodic": "Pruna Cache Periodic",
+        "CacheModelAuto": "Pruna Cache Auto",
     }
     NODE_CLASS_MAPPINGS.update(PRUNA_NODE_CLASS_MAPPINGS)
     NODE_DISPLAY_NAME_MAPPINGS.update(PRUNA_NODE_DISPLAY_NAME_MAPPINGS)

--- a/cache_nodes.py
+++ b/cache_nodes.py
@@ -1,34 +1,29 @@
 import comfy.model_patcher
 
 try:
-    from pruna_pro import smash, SmashConfig
+    from pruna_pro import SmashConfig, smash
 except ImportError:
     print("pruna_pro not installed, skipping")
     try:
-        from pruna import smash, SmashConfig
+        from pruna import SmashConfig, smash
     except ImportError:
         print("Neither pruna_pro nor pruna are installed, skipping")
 
 
-class CacheModel:    
-
+class CacheModelAdaptive:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model": ("MODEL",),               
-                "threshold": ("FLOAT", {
-                    "default": 0.01,
-                    "step": 0.001,
-                    "min": 0.001,
-                    "max": 0.2
-                }),
-                "max_skip_steps": ("INT", {
-                    "default": 4,
-                    "step": 1,
-                    "min": 1,
-                    "max": 5
-                }),
+                "model": ("MODEL",),
+                "threshold": (
+                    "FLOAT",
+                    {"default": 0.01, "step": 0.001, "min": 0.001, "max": 0.2},
+                ),
+                "max_skip_steps": (
+                    "INT",
+                    {"default": 4, "step": 1, "min": 1, "max": 5},
+                ),
             }
         }
 
@@ -39,7 +34,7 @@ class CacheModel:
         #   - https://github.com/comfyanonymous/ComfyUI/issues/1962#issuecomment-1809574013
         #   - https://github.com/comfyanonymous/ComfyUI/issues/2024
         return float("nan")
-    
+
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply_caching"
     CATEGORY = "Pruna"
@@ -50,7 +45,7 @@ class CacheModel:
         Modify forward pass of the model to use adaptive caching.
         """
 
-        if self.reset_cache:            
+        if self.reset_cache:
             model.model.cache_helper.reset_cache()
             return (model,)
 
@@ -63,13 +58,13 @@ class CacheModel:
         # set up the smash config
         smash_config = SmashConfig()
 
-        try:     
-            smash_config['cachers'] = 'adaptive'
+        try:
+            smash_config["cachers"] = "adaptive"
         except KeyError:
             raise ValueError("Adaptive caching requires pruna_pro to be installed")
 
-        smash_config['adaptive_threshold'] = threshold
-        smash_config['adaptive_max_skip_steps'] = max_skip_steps
+        smash_config["adaptive_threshold"] = threshold
+        smash_config["adaptive_max_skip_steps"] = max_skip_steps
 
         # smash the model
         smashed_model = smash(smashed_patcher.model, smash_config)
@@ -79,3 +74,23 @@ class CacheModel:
         self.reset_cache = True
 
         return (smashed_patcher,)
+
+
+class CacheModelPeriodic:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+            }
+        }
+
+    def apply_caching(self, model):
+        pass
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "apply_caching"
+    CATEGORY = "Pruna"
+
+    def apply_caching(self, model):
+        pass

--- a/cache_nodes.py
+++ b/cache_nodes.py
@@ -42,11 +42,14 @@ class CacheModelMixin:
         for key, value in config_params.items():
             smash_config[key] = value
 
+        # add an attribute to patched to pass the info that it is a comfy model
+        patched.model.diffusion_model.is_comfy = True
+
         # "Smash" the model and update the internal reference
-        smashed_diffusion_model = smash(patched.model.diffusion_model, smash_config)
+        smashed_model = smash(patched.model.diffusion_model, smash_config)
         model_ref_name = "_PrunaProModel__internal_model_ref"
         patched.add_object_patch(
-            "diffusion_model", smashed_diffusion_model.__getattribute__(model_ref_name)
+            "diffusion_model", smashed_model.__getattribute__(model_ref_name)
         )
 
         return patched

--- a/cache_nodes.py
+++ b/cache_nodes.py
@@ -10,9 +10,52 @@ except ImportError:
         print("Neither pruna_pro nor pruna are installed, skipping")
 
 
-class CacheModelAdaptive:
+# Base mixin that contains the common functionality
+class CacheModelMixin:
+    def _clone_patcher(self, model):
+        """Clone the model patcher from a given model instance."""
+        if isinstance(model, comfy.model_patcher.ModelPatcher):
+            return model.clone()
+        else:
+            # Assume model has a .patcher attribute, then clone it.
+            return model.patcher.clone()
+
+    def _apply_common_caching(self, model, caching_type, config_params, error_message):
+        """
+        Apply common caching steps:
+           - Clone the model patcher.
+           - Create a smash config and set the caching type.
+           - Update config with caching-specific parameters.
+           - Smash and patch the model.
+        """
+        patched = self._clone_patcher(model)
+
+        # Set up the smash configuration object
+        smash_config = SmashConfig()
+
+        try:
+            smash_config["cachers"] = caching_type
+        except KeyError:
+            raise ValueError(error_message)
+
+        # Merge the given caching-specific parameters into the config
+        for key, value in config_params.items():
+            smash_config[key] = value
+
+        # "Smash" the model and update the internal reference
+        smashed_diffusion_model = smash(patched.model.diffusion_model, smash_config)
+        model_ref_name = "_PrunaProModel__internal_model_ref"
+        patched.add_object_patch(
+            "diffusion_model", smashed_diffusion_model.__getattribute__(model_ref_name)
+        )
+
+        return patched
+
+
+# CacheModelAdaptive now simply supplies its specific config parameters
+class CacheModelAdaptive(CacheModelMixin):
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "model": ("MODEL",),
@@ -27,70 +70,90 @@ class CacheModelAdaptive:
             }
         }
 
-    @classmethod
-    def IS_CHANGED(cls, model, threshold, max_skip_steps):
-        # Force node to re-run on every execution by returning NaN
-        # For more details, see:
-        #   - https://github.com/comfyanonymous/ComfyUI/issues/1962#issuecomment-1809574013
-        #   - https://github.com/comfyanonymous/ComfyUI/issues/2024
-        return float("nan")
-
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply_caching"
     CATEGORY = "Pruna"
-    reset_cache: bool = False  # flag to reset the cache
 
     def apply_caching(self, model, threshold, max_skip_steps):
-        """
-        Modify forward pass of the model to use adaptive caching.
-        """
+        # Prepare caching-specific configuration
+        config_params = {
+            "adaptive_threshold": threshold,
+            "adaptive_max_skip_steps": max_skip_steps,
+        }
+        patched = self._apply_common_caching(
+            model,
+            caching_type="adaptive",
+            config_params=config_params,
+            error_message="Adaptive caching requires pruna_pro to be installed",
+        )
 
-        if self.reset_cache:
-            model.model.cache_helper.reset_cache()
-            return (model,)
-
-        if isinstance(model, comfy.model_patcher.ModelPatcher):
-            smashed_patcher = model.clone()
-        else:
-            smashed_patcher = model.patcher
-            smashed_patcher = smashed_patcher.clone()
-
-        # set up the smash config
-        smash_config = SmashConfig()
-
-        try:
-            smash_config["cachers"] = "adaptive"
-        except KeyError:
-            raise ValueError("Adaptive caching requires pruna_pro to be installed")
-
-        smash_config["adaptive_threshold"] = threshold
-        smash_config["adaptive_max_skip_steps"] = max_skip_steps
-
-        # smash the model
-        smashed_model = smash(smashed_patcher.model, smash_config)
-
-        # patch the model
-        smashed_patcher.model = smashed_model._PrunaProModel__internal_model_ref
-        self.reset_cache = True
-
-        return (smashed_patcher,)
+        return (patched,)
 
 
-class CacheModelPeriodic:
+# CacheModelPeriodic also supplies its own configuration parameters
+class CacheModelPeriodic(CacheModelMixin):
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "model": ("MODEL",),
+                "cache_interval": ("INT", {"default": 2, "min": 1, "max": 7}),
+                "start_step": ("INT", {"default": 2, "min": 0, "max": 10}),
+                "cache_mode": (
+                    "STRING",
+                    {"default": "default", "options": ["default", "taylor"]},
+                ),
             }
         }
-
-    def apply_caching(self, model):
-        pass
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply_caching"
     CATEGORY = "Pruna"
 
-    def apply_caching(self, model):
-        pass
+    def apply_caching(self, model, cache_interval, start_step, cache_mode):
+        # Prepare caching-specific configuration
+        config_params = {
+            "periodic_cache_interval": cache_interval,
+            "periodic_start_step": start_step,
+            "periodic_cache_mode": cache_mode,
+        }
+        patched = self._apply_common_caching(
+            model,
+            caching_type="periodic",
+            config_params=config_params,
+            error_message="Periodic caching requires pruna_pro to be installed",
+        )
+
+        return (patched,)
+
+
+class CacheModelAuto(CacheModelMixin):
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"model": ("MODEL",)},
+            "optional": {
+                "speed_factor": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0}),
+                "cache_mode": (
+                    "STRING",
+                    {"default": "default", "options": ["default", "taylor"]},
+                ),
+            },
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "apply_caching"
+    CATEGORY = "Pruna"
+
+    def apply_caching(self, model, speed_factor, cache_mode):
+        config_params = {
+            "auto_speed_factor": speed_factor,
+            "auto_cache_mode": cache_mode,
+        }
+        patched = self._apply_common_caching(
+            model,
+            caching_type="auto",
+            config_params=config_params,
+            error_message="Auto caching requires pruna_pro to be installed",
+        )
+        return (patched,)

--- a/cache_nodes.py
+++ b/cache_nodes.py
@@ -20,16 +20,11 @@ class CacheModelMixin:
             return model.patcher.clone()
 
     def _apply_common_caching(self, model, caching_method, hyperparams):
-        """
-        Apply common caching steps:
-           - Clone the model patcher.
-           - Create a smash config and set the caching type.
-           - Update config with caching-specific parameters.
-           - Smash and patch the model.
-        """
+        """Apply a specific caching method to a model."""
+        # Clone the model patcher
         model_patcher = self._clone_patcher(model)
 
-        # Set up the smash configuration object
+        # Set up smash config
         smash_config = SmashConfig()
 
         try:
@@ -39,15 +34,15 @@ class CacheModelMixin:
                 f"{caching_method} caching requires pruna_pro to be installed"
             )
 
-        # Merge the given caching-specific parameters into the config
+        # Merge the hyperparameters into smash config
         for key, value in hyperparams.items():
             smash_config[key] = value
         smash_config._prepare_saving = False
 
-        # add an attribute to patched to pass the info that it is a comfy model
+        # Add an attribute to patched to pass the info that it is a comfy model
         model_patcher.model.diffusion_model.is_comfy = True
 
-        # "Smash" the model and update the internal reference
+        # Smash the model and update the internal reference
         smashed_model = smash(model_patcher.model.diffusion_model, smash_config)
         model_patcher.add_object_patch(
             "diffusion_model",
@@ -76,7 +71,7 @@ class CacheModelAdaptive(CacheModelMixin):
                     "STRING",
                     {
                         "default": "torch_compile",
-                        "options": ["torch_compile", "none"],
+                        "options": ["torch_compile", "stable_fast", "none"],
                     },
                 ),
             }
@@ -120,7 +115,7 @@ class CacheModelPeriodic(CacheModelMixin):
                     "STRING",
                     {
                         "default": "torch_compile",
-                        "options": ["torch_compile", "none"],
+                        "options": ["torch_compile", "stable_fast", "none"],
                     },
                 ),
             }
@@ -158,7 +153,7 @@ class CacheModelAuto(CacheModelMixin):
                     "STRING",
                     {
                         "default": "torch_compile",
-                        "options": ["torch_compile", "none"],
+                        "options": ["torch_compile", "stable_fast", "none"],
                     },
                 ),
                 "speed_factor": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0}),

--- a/compile_node.py
+++ b/compile_node.py
@@ -2,18 +2,18 @@ import comfy.model_patcher
 
 USE_PRUNA_PRO = False
 try:
-    from pruna_pro import smash, SmashConfig
+    from pruna_pro import SmashConfig, smash
+
     USE_PRUNA_PRO = True
 except ImportError:
     print("pruna_pro not installed, skipping")
     try:
-        from pruna import smash, SmashConfig
+        from pruna import SmashConfig, smash
     except ImportError:
         print("Neither pruna_pro nor pruna are installed, skipping")
 
 
 class CompileModel:
-
     @classmethod
     def INPUT_TYPES(s):
         return {
@@ -26,12 +26,16 @@ class CompileModel:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply_compilation"
     CATEGORY = "Pruna"
-    SUPPORTED_COMPILERS = {"x_fast", "torch_compile", "x-fast"} # x-fast is deprecated, but still supported
+    SUPPORTED_COMPILERS = {
+        "x_fast",
+        "torch_compile",
+        "x-fast",
+    }  # x-fast is deprecated, but still supported
 
     def apply_compilation(self, model, compiler):
-        '''
+        """
         Smash the model using Pruna.
-        '''
+        """
         # we assume that the input model is either a comfy.model_patcher.ModelPatcher
         # or a comfy.model.Model
         if isinstance(model, comfy.model_patcher.ModelPatcher):
@@ -42,27 +46,28 @@ class CompileModel:
 
         smash_config = SmashConfig()
 
+        if compiler not in self.SUPPORTED_COMPILERS:
+            raise ValueError(
+                f"Compiler {compiler} is not a valid compiler. Supported compilers are: {self.SUPPORTED_COMPILERS}"
+            )
 
-        if compiler not in self.SUPPORTED_COMPILERS:    
-            raise ValueError(f"Compiler {compiler} is not a valid compiler. Supported compilers are: {self.SUPPORTED_COMPILERS}")
-
-        try: 
-            smash_config['compiler'] = compiler
+        try:
+            smash_config["compiler"] = compiler
         except KeyError:
             raise ValueError(f"Compiler {compiler} is available only with pruna_pro")
 
-        
         smash_config._prepare_saving = False
         smashed_diffusion_model = smash(
             smashed_patcher.model.diffusion_model,
             smash_config,
         )
 
-        model_ref_name = "_PrunaProModel__internal_model_ref" if USE_PRUNA_PRO else "model"
+        model_ref_name = (
+            "_PrunaProModel__internal_model_ref" if USE_PRUNA_PRO else "model"
+        )
 
         smashed_patcher.add_object_patch(
-            "diffusion_model",
-            smashed_diffusion_model.__getattribute__(model_ref_name)
+            "diffusion_model", smashed_diffusion_model.__getattribute__(model_ref_name)
         )
 
         return (smashed_patcher,)

--- a/install.py
+++ b/install.py
@@ -1,55 +1,22 @@
 import subprocess
 import sys
 
-def install(package, extra_index_url=None):
+
+def install(package):
     """
-    Install a pip package, optionally using an extra index URL.
-    
+    Install a pip package.
+
     Args:
         package (str): The package to install.
-        extra_index_url (str, optional): URL of the extra package index.
     """
     command = [sys.executable, "-m", "pip", "install", package]
-    if extra_index_url:
-        command.extend(["--extra-index-url", extra_index_url])
     try:
         subprocess.check_call(command)
     except subprocess.CalledProcessError as e:
         print(f"Installation failed for {package}: {e}")
         sys.exit(1)
 
-def ask_choice(prompt, choices, default=None):
-    """
-    Prompt the user to select from a list of choices.
-    
-    Args:
-        prompt (str): The question to display.
-        choices (list): List of valid choices.
-        default (str, optional): The default choice if no input is given.
-    
-    Returns:
-        str: The validated user choice.
-    """
-    choices_str = "/".join(
-        [f"[{c}]" if c == default else c for c in choices]
-    )
-    while True:
-        print(f"{prompt} ({choices_str}): ", end="", flush=True)
-        response = input().strip().lower()
-        if not response and default:
-            return default
-        if response in choices:
-            return response
-        print(f"Invalid choice. Please choose from: {', '.join(choices)}")
 
 if __name__ == "__main__":
-    # Ask the user which package to install
-    pkg = ask_choice("Which package do you want to use?", ["pruna", "pruna_pro"], default="pruna")
-
-    print(f"\nInstalling: {pkg} ...")
-    
-    # install stable-fast in any case 
+    install("pruna_pro")
     install("pruna[stable-fast]")
-
-    if pkg == "pruna_pro":
-        install("pruna_pro")


### PR DESCRIPTION
# :rocket: Add support for periodic and auto caching 

## Summary 
This PR introduces two new caching nodes, one for auto caching and one for periodic caching. 

## Changes 
- We now provide 4 Pruna nodes:
  - `Pruna Compile`: It compiles the given model, as in the previous version, with `torch_compile` or `x_fast`. 
  - `Pruna Cache Adaptive`: As in the previous version. However, now, there is no need for resetting the cache here, as this is handled by Pruna. 
  - `Pruna cache Periodic` Applies periodic caching. 
  - `Pruna cache auto` Applies auto caching. 
-  Compilation can be applied in top of each caching node, by setting the respective parameter. Available compilers to be combined with caching are `torch_compile` and `stable_fast`. In contrast with the previous version,  our `compile` and `caching` nodes are not meant to be combined. 
- The `install.py` file (it is invoked if someone installs our nodes from the registry) now installs directly `pruna_pro`. Asking the user if they prefer `pruna` or `pruna_pro` with a prompt did not work well.  

## Open issues 
- Workflows and performance metrics have not yet updated 
