### PR TITLE
Add ab and bdf caching modes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Currently, running our nodes requires a **Linux system with a GPU**. To setup yo
 
 - To install **Pruna**:
   ```bash
-  pip install pruna==0.2.3
+  pip install pruna==0.2.6
   ```
 - To install **Pruna Pro**:
   ```bash
-  pip install pruna_pro==0.2.3
+  pip install pruna_pro==0.2.6
   ```
 
 **To use Pruna Pro**, you also need to: 
@@ -42,7 +42,7 @@ export PRUNA_TOKEN=<your_token_here>
 ```
 2. [*Optional*] If you want to use the the `x-fast` or `stable-fast` compiler, you need to install additional dependencies:
 ```bash
-pip install pruna[stable-fast]==0.2.3
+pip install pruna[stable-fast]==0.2.6
 ``` 
 
 
@@ -148,7 +148,7 @@ Below, is a summary of the available parameters for each caching node.
 | Parameter | Options | Description |
 |-----------|---------|-------------|
 | `compiler` | `torch_compile`, `none`, `stable_fast` | Compiler to apply on top of caching |
-| `cache_mode` | `default`, `taylor` | Caching mode (`default` reuses previous steps, `taylor` uses Taylor expansion for more accurate approximation) |
+| `cache_mode` | `default`, `taylor`, `ab`, `bdf` | Caching mode. The `default` mode follows a simple caching strategy, while `taylor` uses Taylor expansion for more accurate approximation. `ab` and `bdf` use the Adams-Bashforth and Backward Differentiation Formula, respectively, to approximate the model output. |
 
 **Node-Specific Parameters:**
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Below, is a summary of the available parameters for each caching node.
 | Parameter | Options | Description |
 |-----------|---------|-------------|
 | `compiler` | `torch_compile`, `none`, `stable_fast` | Compiler to apply on top of caching |
-| `cache_mode` | `default`, `taylor`, `ab`, `bdf` | Caching mode. The `default` mode follows a simple caching strategy, while `taylor` uses Taylor expansion for more accurate approximation. `ab` and `bdf` use the Adams-Bashforth and Backward Differentiation Formula, respectively, to approximate the model output. |
+| `cache_mode` | `default`, `taylor`, `ab`, `bdf` | Caching mode. The `default` mode simply reuses previous steps, while `taylor` uses Taylor expansion for more accurate approximation. `ab` and `bdf` use the Adams-Bashforth and Backward Differentiation Formula, respectively, to approximate the model output. |
 
 **Node-Specific Parameters:**
 

--- a/cache_nodes.py
+++ b/cache_nodes.py
@@ -28,7 +28,7 @@ class CacheModelMixin:
         smash_config = SmashConfig()
 
         try:
-            smash_config["cachers"] = caching_method
+            smash_config["cacher"] = caching_method
         except KeyError:
             raise ValueError(
                 f"{caching_method} caching requires pruna_pro to be installed"
@@ -69,7 +69,10 @@ class CacheModelAdaptive(CacheModelMixin):
                 ),
                 "cache_mode": (
                     "STRING",
-                    {"default": "default", "options": ["default", "taylor"]},
+                    {
+                        "default": "default",
+                        "options": ["default", "taylor", "ab", "bdf"],
+                    },
                 ),
                 "compiler": (
                     "STRING",
@@ -114,7 +117,10 @@ class CacheModelPeriodic(CacheModelMixin):
                 "start_step": ("INT", {"default": 2, "min": 0, "max": 10}),
                 "cache_mode": (
                     "STRING",
-                    {"default": "default", "options": ["default", "taylor"]},
+                    {
+                        "default": "default",
+                        "options": ["default", "taylor", "ab", "bdf"],
+                    },
                 ),
                 "compiler": (
                     "STRING",
@@ -157,7 +163,10 @@ class CacheModelAuto(CacheModelMixin):
                 "speed_factor": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0}),
                 "cache_mode": (
                     "STRING",
-                    {"default": "default", "options": ["default", "taylor"]},
+                    {
+                        "default": "default",
+                        "options": ["default", "taylor", "ab", "bdf"],
+                    },
                 ),
                 "compiler": (
                     "STRING",


### PR DESCRIPTION
# Description 
This PR adds support for two new caching modes, namely `ab` and `bdf`. 

# Changes 
* Add `ab` and `bdf` to the list of accepted hyperpamaters.
* Updated the relevant parts in the documentation